### PR TITLE
Add StatusPage.io functionality.

### DIFF
--- a/README.org
+++ b/README.org
@@ -2,6 +2,7 @@
   - Pagerduty support (integration, incidents)
   - Pingdom support (checks, results, actions)
   - Loggly support (event, search, facets)
+  - StatusPage support (incidents, components)
   [[https://github.com/portertech/redphone/raw/master/redphone.jpg]]
   - All API request are done over SSL
   - Response bodies are returned as Ruby hashes
@@ -75,5 +76,36 @@
   You can add the following options for a date range
   : :from => "2011-08-01T12:00:00Z",
   : :until => "2011-10-01T12:00:00Z"
+** StatusPage.io
+  : require "redphone/statuspage"
+  : statuspage = Redphone::Statuspage.new(
+  :   :page_id => PAGE_ID,
+  :   :api_key => API_KEY
+  : )
+  Create a realtime incident
+  : response = statuspage.create_realtime_incident(
+  :   :name => "testing",
+  :   :status => "identified",
+  :   :wants_twitter_update => "t",
+  :   :message => "testing message"
+  : )
+  Update an incident
+  : incident_id = response["id"]
+  : statuspage.update_incident(
+  :   :name => "testing",
+  :   :status => "resolved",
+  :   :wants_twitter_update => "t"
+  :   :incident_id => incident_id
+  : )
+  Delete an incident
+  : statuspage.delete_incident(
+  :   :incident_id => incident_id
+  : )
+  Update a component status
+  : statuspage.update_component(
+  :   :component_id => COMPONENT_ID,
+  :   :status => "major_outage"
+  : )
 * Contributors
   - [[http://portertech.ca][Sean Porter]]
+  - [[http://github.com/perryh][Perry Huang]]

--- a/lib/redphone/helpers.rb
+++ b/lib/redphone/helpers.rb
@@ -33,6 +33,8 @@ def http_request(options={})
     Net::HTTP::Put.new(request_uri)
   when "delete"
     Net::HTTP::Delete.new(request_uri)
+  when "patch"
+    Net::HTTP::Patch.new(request_uri)
   else
     raise "Unknown HTTP method: #{method}"
   end

--- a/lib/redphone/statuspage.rb
+++ b/lib/redphone/statuspage.rb
@@ -85,7 +85,7 @@ module Redphone
         @request_options.merge({
           :method => "delete",
           :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}.json"
-        )}
+        })
       )
       JSON.parse(response.body)
     end
@@ -94,11 +94,11 @@ module Redphone
       check_incident_attributes(options, [:incident_id, :incident_update_id])
       parameter_options = Hash.new
       parameter_options["incident_update[body]"] = options[:body] unless options[:body].nil?
-      parameter_options["incident_update[display_at]"] => options[:display_at] unless options[:display_at].nil?
+      parameter_options["incident_update[display_at]"] = options[:display_at] unless options[:display_at].nil?
       response = http_request(
         @request_options.merge({
           :method => "patch",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json"
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json",
           :parameters => parameter_options
         })
       )

--- a/lib/redphone/statuspage.rb
+++ b/lib/redphone/statuspage.rb
@@ -1,0 +1,108 @@
+require File.join(File.dirname(__FILE__), 'helpers')
+
+module Redphone
+  class Statuspage
+    def initialize(options={})
+      has_options(options, [:api_key, :page_id])
+      @page_id = options[:page_id]
+      @request_options = {
+        :ssl => true,
+        :headers => {"Authorization" => "OAuth #{options[:api_key]}"}
+      }
+    end
+
+    def convert_options(options={})
+      incident_options = Hash.new
+      options.each do |key, val|
+        incident_options["incident[#{key}]"] = val
+      end
+      return incident_options
+    end
+
+    def check_incident_attributes(options={}, checked_options=[])
+      checked_options.each do |option|
+        raise "You must supply an incident #{option}." if options[option].nil?
+      end
+    end
+
+    def create_realtime_incident(options={})
+      check_incident_attributes(options, [:name, :wants_twitter_update])
+      options = convert_options(options)
+      response = http_request(
+        @request_options.merge({
+          :method => "post",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :parameters => options
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def create_scheduled_incident(options={})
+      check_incident_attributes(options, [:name, :status, :wants_twitter_update, :scheduled_for, :scheduled_until])
+      options = convert_options(options)
+      response = http_request(
+        @request_options.merge({
+          :method => "post",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :parameters => options
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def create_historical_incident(options={})
+      check_incident_attributes(options, [:name, :message, :backfilled, :backfill_date])
+      options = convert_options(options)
+      response = http_request(
+        @request_options.merge({
+          :method => "post",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :parameters => options
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def update_incident(options={})
+      check_incident_attributes(options, [:name, :wants_twitter_update, :incident_id])
+      incident_id = options[:incident_id]
+      options.delete(:incident_id)
+      options = convert_options(options)
+      response = http_request(
+        @request_options.merge({
+          :method => "patch",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{incident_id}.json",
+          :parameters => options
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def delete_incident(options={})
+      check_incident_attributes(options, [:incident_id])
+      response = http_request(
+        @request_options.merge({
+          :method => "delete",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}.json"
+        )}
+      )
+      JSON.parse(response.body)
+    end
+  
+    def tune_incident_update(options={})
+      check_incident_attributes(options, [:incident_id, :incident_update_id])
+      parameter_options = Hash.new
+      parameter_options["incident_update[body]"] = options[:body] unless options[:body].nil?
+      parameter_options["incident_update[display_at]"] => options[:display_at] unless options[:display_at].nil?
+      response = http_request(
+        @request_options.merge({
+          :method => "patch",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json"
+          :parameters => parameter_options
+        })
+      )
+      JSON.parse(response.body)
+    end
+  end
+end

--- a/lib/redphone/statuspage.rb
+++ b/lib/redphone/statuspage.rb
@@ -19,14 +19,24 @@ module Redphone
       return incident_options
     end
 
-    def check_incident_attributes(options={}, checked_options=[])
+    def check_attributes(options={}, checked_options=[])
       checked_options.each do |option|
         raise "You must supply an incident #{option}." if options[option].nil?
       end
     end
 
+    def get_all_incidents()
+      response = http_request(
+        @request_options.merge({
+          :method => "get",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json"
+        })
+      )
+      JSON.parse(response.body)
+    end
+
     def create_realtime_incident(options={})
-      check_incident_attributes(options, [:name, :wants_twitter_update])
+      check_attributes(options, [:name, :wants_twitter_update])
       options = convert_options(options)
       response = http_request(
         @request_options.merge({
@@ -39,7 +49,7 @@ module Redphone
     end
 
     def create_scheduled_incident(options={})
-      check_incident_attributes(options, [:name, :status, :wants_twitter_update, :scheduled_for, :scheduled_until])
+      check_attributes(options, [:name, :status, :wants_twitter_update, :scheduled_for, :scheduled_until])
       options = convert_options(options)
       response = http_request(
         @request_options.merge({
@@ -52,7 +62,7 @@ module Redphone
     end
 
     def create_historical_incident(options={})
-      check_incident_attributes(options, [:name, :message, :backfilled, :backfill_date])
+      check_attributes(options, [:name, :message, :backfilled, :backfill_date])
       options = convert_options(options)
       response = http_request(
         @request_options.merge({
@@ -65,7 +75,7 @@ module Redphone
     end
 
     def update_incident(options={})
-      check_incident_attributes(options, [:name, :wants_twitter_update, :incident_id])
+      check_attributes(options, [:name, :wants_twitter_update, :incident_id])
       incident_id = options[:incident_id]
       options.delete(:incident_id)
       options = convert_options(options)
@@ -80,7 +90,7 @@ module Redphone
     end
 
     def delete_incident(options={})
-      check_incident_attributes(options, [:incident_id])
+      check_attributes(options, [:incident_id])
       response = http_request(
         @request_options.merge({
           :method => "delete",
@@ -91,7 +101,7 @@ module Redphone
     end
   
     def tune_incident_update(options={})
-      check_incident_attributes(options, [:incident_id, :incident_update_id])
+      check_attributes(options, [:incident_id, :incident_update_id])
       parameter_options = Hash.new
       parameter_options["incident_update[body]"] = options[:body] unless options[:body].nil?
       parameter_options["incident_update[display_at]"] = options[:display_at] unless options[:display_at].nil?
@@ -99,6 +109,29 @@ module Redphone
         @request_options.merge({
           :method => "patch",
           :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json",
+          :parameters => parameter_options
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def get_all_components()
+      response = http_request(
+        @request_options.merge({
+          :method => "get",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/components.json"
+        })
+      )
+      JSON.parse(response.body)
+    end
+
+    def update_component(options={})
+      check_attributes(options, [:component_id, :status])
+      parameter_options = {"component[status]" => options[:status]}
+      response = http_request(
+        @request_options.merge({
+          :method => "patch",
+          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/components/#{options[:component_id]}.json",
           :parameters => parameter_options
         })
       )

--- a/lib/redphone/statuspage.rb
+++ b/lib/redphone/statuspage.rb
@@ -9,6 +9,7 @@ module Redphone
         :ssl => true,
         :headers => {"Authorization" => "OAuth #{options[:api_key]}"}
       }
+      @api_url = "https://api.statuspage.io/v1/pages/#{@page_id}/"
     end
 
     def convert_options(options={})
@@ -29,7 +30,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "get",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json"
+          :uri => @api_url + "incidents.json"
         })
       )
       JSON.parse(response.body)
@@ -41,7 +42,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "post",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :uri => @api_url + "incidents.json",
           :parameters => options
         })
       )
@@ -54,7 +55,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "post",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :uri => @api_url + "incidents.json",
           :parameters => options
         })
       )
@@ -67,7 +68,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "post",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents.json",
+          :uri => @api_url + "incidents.json",
           :parameters => options
         })
       )
@@ -82,7 +83,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "patch",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{incident_id}.json",
+          :uri => @api_url + "incidents/#{incident_id}.json",
           :parameters => options
         })
       )
@@ -94,7 +95,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "delete",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}.json"
+          :uri => @api_url + "incidents/#{options[:incident_id]}.json"
         })
       )
       JSON.parse(response.body)
@@ -108,7 +109,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "patch",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json",
+          :uri => @api_url + "incidents/#{options[:incident_id]}/incident_updates/#{options[:incident_update_id]}.json",
           :parameters => parameter_options
         })
       )
@@ -119,7 +120,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "get",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/components.json"
+          :uri => @api_url + "components.json"
         })
       )
       JSON.parse(response.body)
@@ -131,7 +132,7 @@ module Redphone
       response = http_request(
         @request_options.merge({
           :method => "patch",
-          :uri => "https://api.statuspage.io/v0/organizations/#{@page_id}/components/#{options[:component_id]}.json",
+          :uri => @api_url + "components/#{options[:component_id]}.json",
           :parameters => parameter_options
         })
       )

--- a/test/statuspage_test.rb
+++ b/test/statuspage_test.rb
@@ -1,0 +1,104 @@
+$: << File.dirname(__FILE__) + '/../lib' unless $:.include?(File.dirname(__FILE__) + '/../lib/')
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+gem 'minitest'
+require 'minitest/autorun'
+require 'redphone/statuspage'
+
+STATUSPAGE_PAGE_ID = "YOURPAGEID"
+STATUSPAGE_API_KEY = "YOURAPIKEY"
+
+class TestRedphoneStatuspage < MiniTest::Unit::TestCase
+  def setup
+  	@statuspage = Redphone::Statuspage.new(
+      :page_id => STATUSPAGE_PAGE_ID,
+      :api_key => STATUSPAGE_API_KEY
+    )
+  end
+
+  def test_create_realtime_incident
+    response = @statuspage.create_realtime_incident(
+      :name => "testing",
+      :status => "identified",
+      :wants_twitter_update => "f",
+      :message => "testing message"
+    )
+    assert_equal 'identified', response['status']
+  end
+
+  def test_create_scheduled_incident
+    response = @statuspage.create_scheduled_incident(
+      :name => "testing scheduled",
+      :status => "scheduled",
+      :scheduled_for => "2014-04-22T01:00:00Z",
+      :scheduled_until => "3000-04-22T03:00:00Z",
+      :wants_twitter_update => "f",
+      :messsage => "testing message"
+    )
+    assert_equal 'scheduled', response['status']
+  end
+
+  def test_create_historical_incident
+    response = @statuspage.create_historical_incident(
+      :name => "testing historical",
+      :message => "testing message",
+      :backfilled => "t",
+      :backfill_date => "2013-04-01"
+    )
+    assert_equal 'resolved', response['status']
+  end
+
+  def test_update_incident
+    response = @statuspage.create_realtime_incident(
+      :name => "testing",
+      :status => "identified",
+      :wants_twitter_update => "f",
+      :message => "testing message"
+    )
+    incident_id = response["id"]
+    response = @statuspage.update_incident(
+      :name => "testing",
+      :status => "resolved",
+      :wants_twitter_update => "f",
+      :incident_id => incident_id
+    )
+    assert_equal 'resolved', response['status']
+  end
+
+  def test_delete_incident
+    response = @statuspage.create_realtime_incident(
+      :name => "this incident will be removed.",
+      :status => "investigating",
+      :wants_twitter_update => "f",
+      :message => "testing message"
+    )
+    incident_status = response["status"]
+    incident_id = response["id"]
+    response = @statuspage.delete_incident(
+      :incident_id => incident_id
+    )
+    assert_equal incident_status, response['status']
+  end
+
+  def test_tune_update_incident
+    response = @statuspage.create_realtime_incident(
+      :name => "this incident will be updated",
+      :status => "investigating",
+      :wants_twitter_update => "f",
+      :message => "testing message"
+    )
+    incident_id = response["id"]
+    response = @statuspage.update_incident(
+      :name => "this update will be tuned later",
+      :status => "resolved",
+      :wants_twitter_update => "f",
+      :incident_id => incident_id
+    )
+    incident_update_id = response["incident_updates"].first["id"]
+    response = @statuspage.tune_incident_update(
+      :incident_id => incident_id,
+      :incident_update_id => incident_update_id,
+      :body => "updated incident new body",
+    )
+    assert_equal 'updated incident new body', response['body']
+  end
+end

--- a/test/statuspage_test.rb
+++ b/test/statuspage_test.rb
@@ -106,7 +106,6 @@ class TestRedphoneStatuspage < MiniTest::Unit::TestCase
     test_component_id = @statuspage.get_all_components.first["id"]
 
     response = @statuspage.update_component(
-      :method => "patch",
       :component_id => test_component_id,
       :status => "major_outage"
     )

--- a/test/statuspage_test.rb
+++ b/test/statuspage_test.rb
@@ -101,4 +101,15 @@ class TestRedphoneStatuspage < MiniTest::Unit::TestCase
     )
     assert_equal 'updated incident new body', response['body']
   end
+
+  def test_update_component
+    test_component_id = @statuspage.get_all_components.first["id"]
+
+    response = @statuspage.update_component(
+      :method => "patch",
+      :component_id => test_component_id,
+      :status => "major_outage"
+    )
+    assert_equal 'major_outage', response['status']
+  end
 end


### PR DESCRIPTION
This communicates with the StatusPage.io API for incidents. I want to add this to Redphone in order to use this to add a handler to Sensu to work with StatusPage.io (will work on this too). I will add test cases when I think of good way to write them (noticed that passwords were read from text files in the other test cases).
