### PR TITLE
truncate PagerDuty description to 1024 chars

### DIFF
--- a/lib/redphone/pagerduty.rb
+++ b/lib/redphone/pagerduty.rb
@@ -22,6 +22,8 @@ module Redphone
 
     def self.trigger_incident(options={})
       has_options(options, [:service_key, :description])
+      # Truncate description to limit of API
+      options[:description] = options[:description][0, 1024]
       request_body = options.merge!({:event_type => "trigger"})
       integration_api(request_body)
     end


### PR DESCRIPTION
Really, it should never be >1024 characters, but this at least allows incidents to be triggered
