### PR TITLE
Add support for statuspage proxy usage

### DIFF
--- a/lib/redphone/helpers.rb
+++ b/lib/redphone/helpers.rb
@@ -14,7 +14,13 @@ def http_request(options={})
   headers = options[:headers] || Hash.new
   parameters = options[:parameters] || Hash.new
   body = options[:body]
-  http = Net::HTTP.new(uri.host, uri.port)
+  proxy_address = options[:proxy_address]
+  proxy_port = options[:proxy_port]
+  http = if @proxy_address.nil?
+           Net::HTTP.new(uri.host, uri.port)
+         else
+           Net::HTTP::Proxy(@proxy_address, @proxy_port).new(uri.host, uri.port)
+         end
   if options[:ssl] == true
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE

--- a/lib/redphone/statuspage.rb
+++ b/lib/redphone/statuspage.rb
@@ -4,6 +4,8 @@ module Redphone
   class Statuspage
     def initialize(options={})
       has_options(options, [:api_key, :page_id])
+      @proxy_address = options[:proxy_address]
+      @proxy_port = options[:proxy_port]
       @page_id = options[:page_id]
       @request_options = {
         :ssl => true,


### PR DESCRIPTION
I ran into the issue of not being able to use a proxy with sensu-plugins-statuspage (which relies on the Redphone module). I've added code to that project to support basic proxy usage (address and port). I don't currently require a username and password so I've not added it in - but it would be trivial.

My commits here would allow for the handler-statuspage.rb plugin to pass off the vars proxy_address and proxy_port to statuspage.rb (which is instantiated by handler-statuspage.rb) and then be utilized by helpers.rb (if they're set and picked up).

I've tested and verified that these changes work in my environment